### PR TITLE
Set cluster label on instance from plan

### DIFF
--- a/pkg/crossplane/instance.go
+++ b/pkg/crossplane/instance.go
@@ -35,7 +35,7 @@ func (cp *Crossplane) CreateInstance(ctx context.Context, instanceID string, par
 		InstanceIDLabel: instanceID,
 	}
 	// Copy relevant labels from plan
-	for _, l := range []string{ServiceIDLabel, ServiceNameLabel, PlanNameLabel} {
+	for _, l := range []string{ServiceIDLabel, ServiceNameLabel, PlanNameLabel, ClusterLabel} {
 		labels[l] = plan.Labels[l]
 	}
 

--- a/pkg/crossplane/metadata.go
+++ b/pkg/crossplane/metadata.go
@@ -40,6 +40,8 @@ const (
 	BindableLabel = SynToolsBase + "/bindable"
 	// DeletedLabel marks an object as deleted to clean up
 	DeletedLabel = SynToolsBase + "/deleted"
+	// ClusterLabel name of the cluster this instance is deployed to
+	ClusterLabel = SynToolsBase + "/cluster"
 )
 
 // ConvertError converts an error to a proper API error


### PR DESCRIPTION
The plan defines on which cluster an instance should be provisioned. We
persist this decision in a label on the instance.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
