### PR TITLE
Fix Last Operation

### DIFF
--- a/pkg/crossplane/instance.go
+++ b/pkg/crossplane/instance.go
@@ -128,7 +128,6 @@ func (cp *Crossplane) GetInstanceWithPlan(ctx context.Context, instanceID string
 	}
 
 	if cmp.GetLabels()[PlanNameLabel] != plan.Labels[PlanNameLabel] {
-		cp.logger.Debug("instance-not-found-labels-dont-match", lager.Data{"instance-id": instanceID, "plan-labels": plan.Labels})
 		return nil, ErrInstanceNotFound
 	}
 

--- a/pkg/crossplanebroker/crossplanebroker.go
+++ b/pkg/crossplanebroker/crossplanebroker.go
@@ -202,9 +202,13 @@ func (b *CrossplaneBroker) LastOperation(ctx context.Context, instanceID string,
 
 	condition := instance.GetCondition(v1alpha1.TypeReady)
 	op := domain.LastOperation{
-		Description: string(condition.Reason),
+		Description: "Unknown",
 		State:       domain.InProgress,
 	}
+	if desc := string(condition.Reason); len(desc) > 0 {
+		op.Description = desc
+	}
+
 	switch condition.Reason {
 	case v1alpha1.ReasonAvailable:
 		op.State = domain.Succeeded

--- a/pkg/crossplanebroker/crossplanebroker.go
+++ b/pkg/crossplanebroker/crossplanebroker.go
@@ -212,16 +212,17 @@ func (b *CrossplaneBroker) LastOperation(ctx context.Context, instanceID string,
 		if err != nil {
 			return domain.LastOperation{}, crossplane.ConvertError(ctx, err)
 		}
-		logger.Info("finish-provision")
 		if err := sb.FinishProvision(ctx); err != nil {
 			return domain.LastOperation{}, crossplane.ConvertError(ctx, err)
 		}
+		logger.WithData(lager.Data{"reason": condition.Reason, "message": condition.Message}).Info("provision-succeeded")
 	case v1alpha1.ReasonCreating:
 		op.State = domain.InProgress
 		logger.WithData(lager.Data{"reason": condition.Reason, "message": condition.Message}).Info("provision-in-progress")
 	case v1alpha1.ReasonUnavailable:
 	case v1alpha1.ReasonDeleting:
 		op.State = domain.Failed
+		logger.WithData(lager.Data{"reason": condition.Reason, "message": condition.Message}).Info("provision-failed")
 	}
 	return op, nil
 }

--- a/pkg/crossplanebroker/crossplanebroker.go
+++ b/pkg/crossplanebroker/crossplanebroker.go
@@ -203,6 +203,7 @@ func (b *CrossplaneBroker) LastOperation(ctx context.Context, instanceID string,
 	condition := instance.GetCondition(v1alpha1.TypeReady)
 	op := domain.LastOperation{
 		Description: string(condition.Reason),
+		State:       domain.InProgress,
 	}
 	switch condition.Reason {
 	case v1alpha1.ReasonAvailable:
@@ -217,7 +218,9 @@ func (b *CrossplaneBroker) LastOperation(ctx context.Context, instanceID string,
 		}
 	case v1alpha1.ReasonCreating:
 		op.State = domain.InProgress
-	default:
+		logger.WithData(lager.Data{"reason": condition.Reason, "message": condition.Message}).Info("provision-in-progress")
+	case v1alpha1.ReasonUnavailable:
+	case v1alpha1.ReasonDeleting:
 		op.State = domain.Failed
 	}
 	return op, nil


### PR DESCRIPTION
Don't return failed if the status is not yet propagated by Crossplane.

Improve logging.